### PR TITLE
Write protect devmode_enabled to prevent removal on FW 05.40.26

### DIFF
--- a/files/stage3.sh
+++ b/files/stage3.sh
@@ -24,6 +24,7 @@ pkill -9 -f /usr/sbin/update
 # This will prevent shutdown.sh removing our devmode_enabled flag...
 rm -rf /var/luna/preferences/devmode_enabled
 mkdir -p /var/luna/preferences/devmode_enabled
+chattr +i /var/luna/preferences/devmode_enabled
 
 # Cleanup after rootmytv v1
 if [[ -f /media/cryptofs/apps/usr/palm/services/com.palmdts.devmode.service/start-devmode.sh ]] && [[ ! -f /media/cryptofs/apps/usr/palm/services/com.palmdts.devmode.service/start-devmode.sig ]] && ! grep '/var/lib/webosbrew/startup.sh' /media/cryptofs/apps/usr/palm/services/com.palmdts.devmode.service/start-devmode.sh ; then


### PR DESCRIPTION
As mentioned in #46, in FW 05.40.26 the HB channel and installed apps were not persistent across reboots. After the first reboot, right after the exploit is installed, stage3.sh runs and installs the channel. This works because it happens _after_ LG removes 'developer' apps.

Write-protecting the 'devmode_enabled' folder using chattr, the LG service-side of things will fail to remove the folder, and thus the clean-up process of developer apps is prevented. I have not looked into this check further, all I could see it do was remove the "/media/developer" folder - presumably there is a check _somewhere_ for legitimate developer mode, maybe assisted by LG servers or some as-of-yet unknown detection method.

In any case, simply write-protecting 'devmode_enabled' will satisfy the checks LG runs and allow you to keep all your apps across reboots. This is the fix I propose, it's a one-liner. It might be interesting to research how LG determines developer eligibility, but as of writing this simple change is all it takes to protect the HB channel and installed homebrew against removal.

I look forward to your integration, comments, thoughts, and future work. :)