### PR TITLE
Update .../init.d/README.txt to clarify filenaming rules

### DIFF
--- a/files/stage3.sh
+++ b/files/stage3.sh
@@ -57,7 +57,8 @@ touch /var/luna/preferences/webosbrew_block_updates
 
 mkdir -p /var/lib/webosbrew/init.d
 echo "Executable scripts in here will be launched on boot by /var/lib/webosbrew/startup.sh (main startup script)" > /var/lib/webosbrew/init.d/README.txt
-echo "Note the filename may only contain a-zA-Z0-9_- since this is executed by run-parts" >> /var/lib/webosbrew/init.d/README.txt
+echo "Note the filename may only contain a-zA-Z0-9_- (and no .sh/.bash etc.) since this is executed by run-parts" >> /var/lib/webosbrew/init.d/README.txt
+echo "run-parts requires the files to be executable (chmod +x \$file) and to exit with status code 0" >> /var/lib/webosbrew/init.d/README.txt
 
 # This is a load-bearing tee. Don't ask.
 luna-send -a webosbrew -f -n 1 luna://com.webos.notification/createToast '{"sourceId":"webosbrew","message": "Elevating homebrew channel..."}'


### PR DESCRIPTION
Updates the description in `.../init.d/README.txt` to slightly clarify filenaming rules to not include .sh/.bash and to exit properly.

I ran into this while trying to make VirtualHere's USB server launch on startup and had `.sh` at the end of my filename, thus it never launched. So, I added the missing clarifications just in case so others hopefuly don't bump into this little caveat! :)