### PR TITLE
avoid breaking scripts with git autocrlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+# these need to be LF to run on webOS
+/files/* text eol=lf


### PR DESCRIPTION
When checking out with `core.autocrlf` enabled on Windows, the scripts in `files/` would have their line endings converted to CRLF, which prevents them from running on webOS. This commit should prevent the line endings of these files from being changed without affecting anything else.